### PR TITLE
[MI-2968]: Add inverted and destructive button styles with size variants

### DIFF
--- a/src/components/Button/Button.component.tsx
+++ b/src/components/Button/Button.component.tsx
@@ -2,13 +2,20 @@ import React from 'react';
 
 import {Icon} from '@Components/Icon';
 
-import {ButtonProps} from './Button';
+import {ButtonProps, ButtonIconSizeMap} from './Button';
 import {StyledButtonContainer} from './Button.styles';
 
 /**
  * Display the icon and text in button
  */
-const DisplayContent = ({iconName, iconPosition, children}: ButtonProps) => {
+const DisplayContent = ({iconName, iconPosition, children, size = 'md'}: ButtonProps) => {
+    const buttonIconSizeMap: ButtonIconSizeMap = {
+        xs: 10,
+        sm: 12,
+        md: 16,
+        lg: 20,
+    };
+
     /**
      * If "iconName" is present then place the icon according to the given icon position and return children with the icon
      * else return children without an icon
@@ -17,7 +24,7 @@ const DisplayContent = ({iconName, iconPosition, children}: ButtonProps) => {
         const icon = (
             <Icon
                 name={iconName}
-                size={16}
+                size={buttonIconSizeMap[size]}
             />
         );
         if (iconPosition === 'start') {
@@ -69,6 +76,7 @@ export const Button = (props:ButtonProps) => {
             <DisplayContent
                 iconName={iconName}
                 iconPosition={iconPosition}
+                size={size}
             >
                 {children}
             </DisplayContent>

--- a/src/components/Button/Button.component.tsx
+++ b/src/components/Button/Button.component.tsx
@@ -52,6 +52,8 @@ export const Button = (props:ButtonProps) => {
         iconPosition = 'start',
         variant = 'primary',
         className = '',
+        size = 'md',
+        width = 'fit-content',
         ...restProps
     } = props;
 
@@ -60,6 +62,8 @@ export const Button = (props:ButtonProps) => {
             iconPosition={iconPosition}
             variant={variant}
             className={`mm-button ${className}`}
+            size={size}
+            width={width}
             {...restProps}
         >
             <DisplayContent

--- a/src/components/Button/Button.d.ts
+++ b/src/components/Button/Button.d.ts
@@ -55,7 +55,7 @@ export type ButtonSizeTypes = 'xs' | 'sm' | 'md' | 'lg';
 export type ButtonSizeProperties = 'height' | 'fontSize' | 'padding' | 'lineHeight' | 'focusPadding';
 
 /**
- * Type for button color map
+ * Type for button size map
  */
 export type ButtonSizeMap = Record<ButtonSizeTypes, Record<ButtonSizeProperties, string>>;
 

--- a/src/components/Button/Button.d.ts
+++ b/src/components/Button/Button.d.ts
@@ -52,7 +52,7 @@ export type ButtonSizeTypes = 'xs' | 'sm' | 'md' | 'lg';
 /**
  * Type for button properties
  */
-export type ButtonSizeProperties = 'height' | 'fontSize' | 'padding' | 'lineHeight';
+export type ButtonSizeProperties = 'height' | 'fontSize' | 'padding' | 'lineHeight' | 'focusPadding';
 
 /**
  * Type for button color map
@@ -78,22 +78,22 @@ export type ButtonIconSizeMap = Record<ButtonSizeTypes, number>
 export interface StyledButtonProps {
 
     /**
-		 * The variant of the button component
-		 */
+	 * The variant of the button component
+	 */
     variant: VariantType;
 
     /**
-		* Position of the icon
-		*
-		* @default start
-		*/
+	 * Position of the icon
+	 *
+	 * @default start
+	 */
     iconPosition?: IconPositionType;
 
     /**
-		* if `true`, button occupies full width
-		*
-		* @default false
-		*/
+	 * if `true`, button occupies full width
+	 *
+	 * @default false
+	 */
     fullWidth?:boolean;
 
     /**
@@ -130,36 +130,38 @@ export interface StyledButtonProps {
 export interface ButtonProps extends Omit<StyledButtonProps, 'variant'> {
 
     /**
-		 * The variant of the component
-		 *
-		 * @default primary
-		 */
+	 * The variant of the component
+	 *
+	 * @default primary
+	 */
     variant?: VariantType;
 
     /**
-		 * The content of the component
-		 */
+	 * The content of the component
+	 */
     children: React.ReactNode;
 
     /**
-		 * If `true`, the component is disabled
-		 *
-		 * @default false
-		 */
+	 * If `true`, the component is disabled
+	 *
+	 * @default false
+	 */
     disabled?: boolean;
 
     /**
-		 * Name of the icon to use in the component
-		 */
+	 * Name of the icon to use in the component
+	 */
     iconName?: IconType;
 
     /**
-		 * To override or extend the styles applied to the component
-		 */
+	 * To override or extend the styles applied to the component
+	 *
+	 * @default ''
+	 */
     className?: string;
 
     /**
-		 * Perform action on the button click
-		 */
+	 * Perform action on the button click
+	 */
     onClick?: React.MouseEventHandler<HTMLButtonElement>;
 }

--- a/src/components/Button/Button.d.ts
+++ b/src/components/Button/Button.d.ts
@@ -60,6 +60,19 @@ export type ButtonSizeProperties = 'height' | 'fontSize' | 'padding' | 'lineHeig
 export type ButtonSizeMap = Record<ButtonSizeTypes, Record<ButtonSizeProperties, string>>;
 
 /**
+ * Button icon's size types
+ *
+ * `xs` - Icon Size = 10
+ *
+ * `sm` - Icon Size = 12
+ *
+ * `md` - Icon Size = 16
+ *
+ * `lg` - Icon Size = 20
+ */
+export type ButtonIconSizeMap = Record<ButtonSizeTypes, number>
+
+/**
  * Interface for styled button component
  */
 export interface StyledButtonProps {

--- a/src/components/Button/Button.d.ts
+++ b/src/components/Button/Button.d.ts
@@ -37,6 +37,29 @@ export type ButtonState = 'default' | 'hover' | 'active' | 'disabled';
 export type ButtonColorMap = Record<VariantType, Record<ButtonState, string>>;
 
 /**
+ * Button's size types
+ *
+ * `xs` - Button height = 24
+ *
+ * `sm` - Button height = 32
+ *
+ * `md` - Button height = 40
+ *
+ * `lg` - Button height = 48
+ */
+export type ButtonSizeTypes = 'xs' | 'sm' | 'md' | 'lg';
+
+/**
+ * Type for button properties
+ */
+export type ButtonSizeProperties = 'height' | 'fontSize' | 'padding' | 'lineHeight';
+
+/**
+ * Type for button color map
+ */
+export type ButtonSizeMap = Record<ButtonSizeTypes, Record<ButtonSizeProperties, string>>;
+
+/**
  * Interface for styled button component
  */
 export interface StyledButtonProps {
@@ -59,6 +82,33 @@ export interface StyledButtonProps {
 		* @default false
 		*/
     fullWidth?:boolean;
+
+    /**
+	 * Button sizes
+	 *
+	 * @default 'md'
+	 */
+    size?: ButtonSizeTypes;
+
+    /**
+	 * The inverted style of button
+	 *
+	 * @default false
+	 */
+    inverted?: boolean;
+
+    /**
+	 * The destructive style of button
+	 *
+	 * @default false
+	 */
+    destructive?: boolean;
+
+    /**
+	 * The width of the button
+	 * @default fit-content
+	 */
+    width?: string;
 }
 
 /**

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -38,6 +38,21 @@ TextButton.args = {
     variant: 'text',
 };
 
+// destructive button
+export const DestructiveButton = ButtonTemplate.bind({});
+DestructiveButton.args = {
+    variant: 'primary',
+    destructive: true,
+};
+
+// inverted button
+export const InvertedButton = ButtonTemplate.bind({});
+InvertedButton.parameters = {backgrounds: {default: 'dark'}};
+InvertedButton.args = {
+    variant: 'primary',
+    inverted: true,
+};
+
 // Button with icon
 export const IconButton = ButtonTemplate.bind({});
 IconButton.args = {

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -8,8 +8,8 @@ import {ButtonColorMap, ButtonSizeMap, StyledButtonProps} from './Button';
  * Styled container for the Button to configure according to props
  */
 export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant, fullWidth, iconPosition, size = 'md', inverted, destructive, width}) => {
-    // styles depending on different button sizes
-    const increaseButtonSize: ButtonSizeMap = {
+    // button styles depending on different button sizes
+    const buttonStyles: ButtonSizeMap = {
         xs: {
             padding: '6px 10px',
             focusPadding: variant === 'secondary' ? '5px 9px' : '4px 8px',
@@ -40,7 +40,6 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
         },
     };
 
-    // inverted style color map
     const invertedColorMap: ButtonColorMap = {
         primary: {
             default: colors.primaryText,
@@ -74,7 +73,6 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
         },
     };
 
-    // destructive style color map
     const destructiveColorMap: ButtonColorMap = {
         primary: {
             default: colors.error,
@@ -108,7 +106,6 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
         },
     };
 
-    // default color map
     const defaultColorMap: ButtonColorMap = {
         primary: {
             default: colors.primary,
@@ -143,14 +140,14 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
     };
 
     // button styles depending upon prop
-    const getButtonStyle = (): ButtonColorMap => {
+    const getButtonStyle = ((): ButtonColorMap => {
         if (destructive) {
             return destructiveColorMap;
         } else if (inverted) {
             return invertedColorMap;
         }
         return defaultColorMap;
-    };
+    })();
 
     // button text and border color
     const buttonTextColor = ((): string => {
@@ -172,17 +169,15 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
         return colors.primary_16;
     };
 
-    // padding styles
     const padding = () => {
         switch (variant) {
         case 'text':
             return '4px';
         default:
-            return increaseButtonSize[size].padding;
+            return buttonStyles[size].padding;
         }
     };
 
-    // focus styles
     const focus = () => {
         switch (variant) {
         case 'quaternary':
@@ -190,14 +185,14 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
         case 'text':
             return {
                 border: `2px solid ${colors.buttonFocusBorder}`,
-                backgroundColor: getButtonStyle()[variant].default,
+                backgroundColor: getButtonStyle[variant].default,
                 padding: '2px',
             };
         default:
             return {
                 border: `2px solid ${colors.buttonFocusBorder}`,
-                backgroundColor: getButtonStyle()[variant].default,
-                padding: increaseButtonSize[size].focusPadding,
+                backgroundColor: getButtonStyle[variant].default,
+                padding: buttonStyles[size].focusPadding,
             };
         }
     };
@@ -209,19 +204,16 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
         width: fullWidth ? '100%' : width,
         boxSizing: 'border-box',
         cursor: 'pointer',
-        lineHeight: increaseButtonSize[size].lineHeight,
-        fontSize: increaseButtonSize[size].fontSize,
+        lineHeight: buttonStyles[size].lineHeight,
+        fontSize: buttonStyles[size].fontSize,
         fontWeight: '600',
-        height: variant === 'text' ? 'auto' : increaseButtonSize[size].height,
+        height: variant === 'text' ? 'auto' : buttonStyles[size].height,
         borderRadius: variant === 'text' ? 0 : '4px',
-
-        // Styles based on variant
         border: variant === 'secondary' ? `1px solid ${buttonTextColor}` : 'none',
         padding: padding(),
         color: !inverted && variant === 'primary' ? colors.primaryText : buttonTextColor,
-        backgroundColor: getButtonStyle()[variant].default,
+        backgroundColor: getButtonStyle[variant].default,
 
-        // Style for button icon
         '& .mm-icon': {
             display: 'inline',
             marginInline: iconPosition === 'start' ? '0 8px' : '8px 0',
@@ -230,23 +222,19 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
             },
         },
 
-        // Style on hover
         ':hover': {
-            backgroundColor: getButtonStyle()[variant].hover,
+            backgroundColor: getButtonStyle[variant].hover,
         },
 
-        // Style when button is active
         ':active': {
-            backgroundColor: getButtonStyle()[variant].active,
+            backgroundColor: getButtonStyle[variant].active,
         },
 
-        // Style when button is focused
         ':focus': focus(),
 
-        // Style when button is disabled
         ':disabled': {
             color: colors.centerChannel_32,
-            background: getButtonStyle()[variant].disabled,
+            background: getButtonStyle[variant].disabled,
             borderColor: colors.centerChannel_32,
             pointerEvents: 'none',
             cursor: 'default',

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -12,24 +12,28 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
     const increaseButtonSize: ButtonSizeMap = {
         xs: {
             padding: '6px 10px',
+            focusPadding: variant === 'secondary' ? '5px 9px' : '4px 8px',
             fontSize: '10px',
             height: '24px',
             lineHeight: '9px',
         },
         sm: {
             padding: '10px 16px',
+            focusPadding: variant === 'secondary' ? '9px 15px' : '8px 14px',
             fontSize: '12px',
             height: '32px',
             lineHeight: '10px',
         },
         md: {
             padding: '12px 20px',
+            focusPadding: variant === 'secondary' ? '11px 19px' : '10px 18px',
             fontSize: '14px',
             height: '40px',
             lineHeight: '14px',
         },
         lg: {
             padding: '14px 24px',
+            focusPadding: variant === 'secondary' ? '13px 23px' : '12px 22px',
             fontSize: '16px',
             height: '48px',
             lineHeight: '17px',
@@ -149,14 +153,14 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
     };
 
     // button text and border color
-    const getButtonColor = (): string => {
+    const buttonTextColor = ((): string => {
         if (destructive) {
             return colors.error;
         } else if (inverted) {
             return variant === 'primary' ? colors.primary : colors.primaryText;
         }
         return colors.primary;
-    };
+    })();
 
     // focus styles for quaternary variant
     const getQuaternaryButtonFocus = () => {
@@ -193,7 +197,7 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
             return {
                 border: `2px solid ${colors.buttonFocusBorder}`,
                 backgroundColor: getButtonStyle()[variant].default,
-                padding: '10px 18px',
+                padding: increaseButtonSize[size].focusPadding,
             };
         }
     };
@@ -212,9 +216,9 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
         borderRadius: variant === 'text' ? 0 : '4px',
 
         // Styles based on variant
-        border: variant === 'secondary' ? `1px solid ${getButtonColor()}` : 'none',
+        border: variant === 'secondary' ? `1px solid ${buttonTextColor}` : 'none',
         padding: padding(),
-        color: !inverted && variant === 'primary' ? colors.primaryText : getButtonColor(),
+        color: !inverted && variant === 'primary' ? colors.primaryText : buttonTextColor,
         backgroundColor: getButtonStyle()[variant].default,
 
         // Style for button icon
@@ -222,7 +226,7 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
             display: 'inline',
             marginInline: iconPosition === 'start' ? '0 8px' : '8px 0',
             '& path , & rect': {
-                color: !inverted && variant === 'primary' ? colors.primaryText : getButtonColor(),
+                color: !inverted && variant === 'primary' ? colors.primaryText : buttonTextColor,
             },
         },
 

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -2,13 +2,110 @@ import styled from 'styled-components';
 
 import colors from '@Styles/colorsForJs.module.scss';
 
-import {ButtonColorMap, StyledButtonProps} from './Button';
+import {ButtonColorMap, ButtonSizeMap, StyledButtonProps} from './Button';
 
 /**
  * Styled container for the Button to configure according to props
  */
-export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant, fullWidth, iconPosition}) => {
-    const colorMap: ButtonColorMap = {
+export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant, fullWidth, iconPosition, size = 'md', inverted, destructive, width}) => {
+    // styles depending on different button sizes
+    const increaseButtonSize: ButtonSizeMap = {
+        xs: {
+            padding: '6px 10px',
+            fontSize: '10px',
+            height: '24px',
+            lineHeight: '10px',
+        },
+        sm: {
+            padding: '10px 16px',
+            fontSize: '12px',
+            height: '32px',
+            lineHeight: '9.5px',
+        },
+        md: {
+            padding: '12px 20px',
+            fontSize: '14px',
+            height: '40px',
+            lineHeight: '14px',
+        },
+        lg: {
+            padding: '14px 24px',
+            fontSize: '16px',
+            height: '48px',
+            lineHeight: '18px',
+        },
+    };
+
+    // inverted style color map
+    const invertedColorMap: ButtonColorMap = {
+        primary: {
+            default: colors.primaryText,
+            hover: colors.primaryText,
+            active: colors.primaryText,
+            disabled: colors.centerChannel_8,
+        },
+        secondary: {
+            default: 'transparent',
+            hover: colors.primaryText_8,
+            active: colors.primaryText_16,
+            disabled: 'transparent',
+        },
+        tertiary: {
+            default: colors.primaryText_8,
+            hover: colors.primaryText_12,
+            active: colors.primaryText_16,
+            disabled: colors.centerChannel_8,
+        },
+        quaternary: {
+            default: 'transparent',
+            hover: colors.primaryText_8,
+            active: colors.primaryText_12,
+            disabled: 'transparent',
+        },
+        text: {
+            default: 'transparent',
+            hover: 'transparent',
+            active: colors.primaryText_16,
+            disabled: 'transparent',
+        },
+    };
+
+    // destructive style color map
+    const destructiveColorMap: ButtonColorMap = {
+        primary: {
+            default: colors.error,
+            hover: colors.error,
+            active: colors.error,
+            disabled: colors.centerChannel_8,
+        },
+        secondary: {
+            default: 'transparent',
+            hover: colors.error_8,
+            active: colors.error_8,
+            disabled: 'transparent',
+        },
+        tertiary: {
+            default: colors.error_8,
+            hover: colors.error_12,
+            active: colors.error_16,
+            disabled: colors.centerChannel_8,
+        },
+        quaternary: {
+            default: 'transparent',
+            hover: colors.error_8,
+            active: colors.error_12,
+            disabled: 'transparent',
+        },
+        text: {
+            default: 'transparent',
+            hover: 'transparent',
+            active: colors.error_16,
+            disabled: 'transparent',
+        },
+    };
+
+    // default color map
+    const defaultColorMap: ButtonColorMap = {
         primary: {
             default: colors.primary,
             hover: colors.buttonPrimaryHover,
@@ -41,15 +138,43 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
         },
     };
 
+    // button styles depending upon prop
+    const getButtonStyle = (): ButtonColorMap => {
+        if (destructive) {
+            return destructiveColorMap;
+        } else if (inverted) {
+            return invertedColorMap;
+        }
+        return defaultColorMap;
+    };
+
+    // button text and border color
+    const getButtonColor = (): string => {
+        if (destructive) {
+            return colors.error;
+        } else if (inverted) {
+            return variant === 'primary' ? colors.primary : colors.primaryText;
+        }
+        return colors.primary;
+    };
+
+    // focus styles for quaternary variant
+    const getQuaternaryButtonFocus = () => {
+        if (destructive) {
+            return colors.error_16;
+        } else if (inverted) {
+            return colors.primaryText_16;
+        }
+        return colors.primary_16;
+    };
+
     // padding styles
     const padding = () => {
         switch (variant) {
-        case 'secondary':
-            return '11px 19px';
         case 'text':
             return '4px';
         default:
-            return '12px 20px';
+            return increaseButtonSize[size].padding;
         }
     };
 
@@ -57,17 +182,17 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
     const focus = () => {
         switch (variant) {
         case 'quaternary':
-            return {backgroundColor: colors.primary_16};
+            return {backgroundColor: getQuaternaryButtonFocus()};
         case 'text':
             return {
                 border: `2px solid ${colors.buttonFocusBorder}`,
-                backgroundColor: colorMap[variant].default,
+                backgroundColor: getButtonStyle()[variant].default,
                 padding: '2px',
             };
         default:
             return {
                 border: `2px solid ${colors.buttonFocusBorder}`,
-                backgroundColor: colorMap[variant].default,
+                backgroundColor: getButtonStyle()[variant].default,
                 padding: '10px 18px',
             };
         }
@@ -77,38 +202,38 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        width: fullWidth ? '100%' : 'fit-content',
+        width: fullWidth ? '100%' : width,
         boxSizing: 'border-box',
         cursor: 'pointer',
-        lineHeight: '16px',
-        fontSize: '14px',
+        lineHeight: increaseButtonSize[size].lineHeight,
+        fontSize: increaseButtonSize[size].fontSize,
         fontWeight: '600',
-        height: variant === 'text' ? 'auto' : '40px',
+        height: variant === 'text' ? 'auto' : increaseButtonSize[size].height,
         borderRadius: variant === 'text' ? 0 : '4px',
 
         // Styles based on variant
-        border: variant === 'secondary' ? `1px solid ${colors.primary}` : 'none',
+        border: variant === 'secondary' ? `1px solid ${getButtonColor()}` : 'none',
         padding: padding(),
-        color: variant === 'primary' ? colors.primaryText : colors.primary,
-        backgroundColor: colorMap[variant].default,
+        color: !inverted && variant === 'primary' ? colors.primaryText : getButtonColor(),
+        backgroundColor: getButtonStyle()[variant].default,
 
         // Style for button icon
         '& .mm-icon': {
             display: 'inline',
             marginInline: iconPosition === 'start' ? '0 8px' : '8px 0',
             '& path , & rect': {
-                color: variant === 'primary' ? colors.primaryText : colors.primary,
+                color: variant === 'primary' ? colors.primaryText : getButtonColor(),
             },
         },
 
         // Style on hover
         ':hover': {
-            backgroundColor: colorMap[variant].hover,
+            backgroundColor: getButtonStyle()[variant].hover,
         },
 
         // Style when button is active
         ':active': {
-            backgroundColor: colorMap[variant].active,
+            backgroundColor: getButtonStyle()[variant].active,
         },
 
         // Style when button is focused
@@ -117,7 +242,7 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
         // Style when button is disabled
         ':disabled': {
             color: colors.centerChannel_32,
-            background: colorMap[variant].disabled,
+            background: getButtonStyle()[variant].disabled,
             borderColor: colors.centerChannel_32,
             pointerEvents: 'none',
             cursor: 'default',

--- a/src/components/Button/Button.styles.ts
+++ b/src/components/Button/Button.styles.ts
@@ -14,13 +14,13 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
             padding: '6px 10px',
             fontSize: '10px',
             height: '24px',
-            lineHeight: '10px',
+            lineHeight: '9px',
         },
         sm: {
             padding: '10px 16px',
             fontSize: '12px',
             height: '32px',
-            lineHeight: '9.5px',
+            lineHeight: '10px',
         },
         md: {
             padding: '12px 20px',
@@ -32,7 +32,7 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
             padding: '14px 24px',
             fontSize: '16px',
             height: '48px',
-            lineHeight: '18px',
+            lineHeight: '17px',
         },
     };
 
@@ -222,7 +222,7 @@ export const StyledButtonContainer = styled.button<StyledButtonProps>(({variant,
             display: 'inline',
             marginInline: iconPosition === 'start' ? '0 8px' : '8px 0',
             '& path , & rect': {
-                color: variant === 'primary' ? colors.primaryText : getButtonColor(),
+                color: !inverted && variant === 'primary' ? colors.primaryText : getButtonColor(),
             },
         },
 

--- a/src/styles/abstract/_cssVariables.scss
+++ b/src/styles/abstract/_cssVariables.scss
@@ -167,4 +167,6 @@
   --tooltip-hint-text: #959595;
   --no-data-icon:#84878f;
   --menu-secondary-text: rgba(63, 67, 80, 0.56);
+  --error-text-16: rgba(210, 75, 78, 0.16);
+  --button-color-12:rgba(255, 255, 255, 0.12);
 }

--- a/src/styles/colorsForJs.module.scss
+++ b/src/styles/colorsForJs.module.scss
@@ -10,6 +10,9 @@
   primary_16: var(--button-bg-16);
   primary_32: var(--button-bg-32);
   primaryText:var(--button-color);
+  primaryText_8:var(--button-color-08);
+  primaryText_12:var(--button-color-12);
+  primaryText_16:var(--button-color-16);
   centerChannelBg: var(--center-channel-bg);
   centerChannel: var(--center-channel-color);
   centerChannelRgb: var(--center-channel-color-rgb);
@@ -24,6 +27,8 @@
   centerChannel_4: var(--center-channel-color-04);
   error: var(--error-text);
   error_8: var(--error-text-08);
+  error_12: var(--error-text-12);
+  error_16: var(--error-text-16);
   success: var(--online-indicator);
   mentionHighlightBg: var(--mention-highlight-bg);
   mentionHighlightLink: var(--mention-highlight-link);


### PR DESCRIPTION
### Ticket ID
https://brightscout.atlassian.net/browse/MI-2968

### Description
- Add inverted and destructive styles
- Add size variants for Button
- Add prop for fixed width

### Screenshot
![Screenshot from 2023-04-06 10-52-59](https://user-images.githubusercontent.com/115625377/230279519-b9919385-99f8-4c2d-a687-2f433577a6a4.png)
![Screenshot from 2023-04-06 10-53-08](https://user-images.githubusercontent.com/115625377/230279526-bbd330fc-165e-4a04-b99c-0f6cd9f8b1d9.png)
![Screenshot from 2023-04-06 10-54-52](https://user-images.githubusercontent.com/115625377/230279529-52fe9329-af4c-44ee-b61f-969ac28a33e9.png)
