### PR TITLE
[MI-2985]: Add leading and trailing element prop with destructive var…

### DIFF
--- a/src/components/MenuItem/MenuItem.component.tsx
+++ b/src/components/MenuItem/MenuItem.component.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import {Icon} from '@Components/Icon';
-
 import {MenuItemProps} from './MenuItem';
 import {Label, MenuItemWrapper, SecondaryLabel} from './MenuItem.styles';
 
@@ -33,8 +31,18 @@ import {Label, MenuItemWrapper, SecondaryLabel} from './MenuItem.styles';
  * ```ts
  * <MenuItem label='Main Label'
  *           secondaryLabel='Secondary Label'
- *           leadingIcon='Edit'
- *           trailingIcon='Delete'
+ *            leadingElement: <Icon name='Edit' size={16}/>,
+ *              trailingElement: <Icon name='Delete' size={16}/>,
+ * />
+ * ```
+ *
+ * @example destructive usage with trailing and leading icon
+ * ```ts
+ * <MenuItem label='Main Label'
+ *          destructive={true}
+ *           secondaryLabel='Secondary Label'
+ *            leadingElement: <Icon name='Edit' size={16}/>,
+ *              trailingElement: <Icon name='Delete' size={16}/>,
  * />
  * ```
  */
@@ -42,26 +50,24 @@ export const MenuItem = (props: MenuItemProps) => {
     const {
         label,
         secondaryLabel,
-        leadingIcon,
-        trailingIcon,
+        leadingElement,
+        trailingElement,
         secondaryLabelPosition = 'block',
         className = '',
+        disabled = false,
+        destructive = false,
         ...restProps
     } = props;
 
     return (
         <MenuItemWrapper
             tabIndex={0}
-            className={`mm-menuItem ${className}`}
+            className={`mm-menuItem ${className}ss`}
+            disabled={disabled}
+            destructive={destructive}
             {...restProps}
         >
-            {
-                leadingIcon &&
-                    <Icon
-                        name={leadingIcon}
-                        size={16}
-                    />
-            }
+            {leadingElement}
             <Label
                 className='mm-menuItem__label'
                 secondaryLabelPosition={secondaryLabelPosition}
@@ -77,13 +83,7 @@ export const MenuItem = (props: MenuItemProps) => {
                         {secondaryLabel}
                     </SecondaryLabel>
             }
-            {
-                trailingIcon &&
-                    <Icon
-                        name={trailingIcon}
-                        size={16}
-                    />
-            }
+            {trailingElement}
         </MenuItemWrapper>
     );
 };

--- a/src/components/MenuItem/MenuItem.d.ts
+++ b/src/components/MenuItem/MenuItem.d.ts
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import {IconType} from '@Components/Icon';
-
 /**
  * Types of position for the secondary label
  *
@@ -29,19 +27,43 @@ export interface MenuItemProps {
     secondaryLabelPosition?: SecondaryLabelPositionType;
 
     /**
-	 * Leading icon in the menu item
+	 * Leading element in the menu item
 	 */
-    leadingIcon?: Exclude<IconType, 'Spinner'>;
+    leadingElement?: JSX.Element;
 
     /**
-	 * Trailing icon in the menu item
+	 * Trailing element in the menu item
 	 */
-    trailingIcon?: Exclude<IconType, 'Spinner'>;
+    trailingElement?: JSX.Element;
+
+    /**
+     * If 'true', the component is disabled
+     *
+     * @default false
+     */
+    disabled?: boolean;
+
+    /**
+     * if 'true', the component will have destructive styles
+     *
+     * @default false
+     */
+    destructive?: boolean;
 
     /**
 	 * Callback to be triggered on clicking the Menu Item
 	 */
     onClick?: (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => void;
+
+    /**
+	 * Callback to be triggered when mouse is entering the Menu Item
+	 */
+    onMouseEnter?: (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => void;
+
+    /**
+	 * Callback to be triggered when mouse is leaving the Menu Item
+	 */
+    onMouseLeave?: (event: React.MouseEvent<HTMLLIElement, MouseEvent>) => void;
 
     /**
 	 * To override or extend the styles applied to the component

--- a/src/components/MenuItem/MenuItem.stories.tsx
+++ b/src/components/MenuItem/MenuItem.stories.tsx
@@ -3,6 +3,8 @@ import {Story, Meta} from '@storybook/react';
 
 import {MenuItem} from './MenuItem.component';
 import {MenuItemProps} from './MenuItem';
+import {Icon} from '../Icon';
+import {Tag} from '../Tag';
 
 export default {
     title: 'Component/MenuItem',
@@ -23,18 +25,44 @@ MenuItemWithSecondaryLabel.args = {
     secondaryLabel: '@Secondary Label',
 };
 
-export const MenuItemWithLeadingIconAndInlineSecondaryLabel = MenuItemTemplate.bind({});
-MenuItemWithLeadingIconAndInlineSecondaryLabel.args = {
+export const MenuItemWithLeadingElement = MenuItemTemplate.bind({});
+MenuItemWithLeadingElement.args = {
+    label: 'Main Label',
+    leadingElement: <Icon name='User' size={24}/>,
+};
+
+export const MenuItemWithTrailingElement = MenuItemTemplate.bind({});
+MenuItemWithTrailingElement.args = {
+    label: 'Main Label',
+    trailingElement: <Tag type='shortcut' text='16'/>,
+};
+
+export const MenuItemWithLeadingElementAndInlineSecondaryLabel = MenuItemTemplate.bind({});
+MenuItemWithLeadingElementAndInlineSecondaryLabel.args = {
     label: 'Main Label',
     secondaryLabel: '@Secondary label',
     secondaryLabelPosition: 'inline',
-    leadingIcon: 'Edit',
+    leadingElement: <Icon name='Edit' size={16}/>,
 };
 
-export const MenuItemWithLeadingAndTrailingIcon = MenuItemTemplate.bind({});
-MenuItemWithLeadingAndTrailingIcon.args = {
+export const MenuItemWithLeadingAndTrailingElement = MenuItemTemplate.bind({});
+MenuItemWithLeadingAndTrailingElement.args = {
     label: 'Main Label',
     secondaryLabel: '@Secondary Label',
-    leadingIcon: 'Edit',
-    trailingIcon: 'Delete',
+    leadingElement: <Icon name='Edit' size={16}/>,
+    trailingElement: <Icon name='Delete' size={16}/>,
+};
+
+export const DisabledMenuItemWithLeadingElement = MenuItemTemplate.bind({});
+DisabledMenuItemWithLeadingElement.args = {
+    label: 'Main Label',
+    leadingElement: <Icon name='User' size={24}/>,
+    disabled: true
+};
+
+export const DestructiveMenuItemWithLeadingElement = MenuItemTemplate.bind({});
+DestructiveMenuItemWithLeadingElement.args = {
+    label: 'Main Label',
+    leadingElement: <Icon name='User' size={24}/>,
+    destructive: true
 };

--- a/src/components/MenuItem/MenuItem.styles.ts
+++ b/src/components/MenuItem/MenuItem.styles.ts
@@ -4,7 +4,7 @@ import colors from '@Styles/colorsForJs.module.scss';
 
 import {SecondaryLabelPositionType} from './MenuItem';
 
-export const MenuItemWrapper = styled.li(() => {
+export const MenuItemWrapper = styled.li<{disabled?: boolean; destructive?: boolean}>(({disabled = false, destructive = false}) => {
     return {
         display: 'grid',
         alignItems: 'center',
@@ -26,17 +26,47 @@ export const MenuItemWrapper = styled.li(() => {
         },
 
         '&:hover': {
-            background: colors.centerChannel_8,
+            background: destructive ? colors.error : colors.centerChannel_8,
+            cursor: 'pointer',
+
+            ...(destructive && {
+                '.mm-menuItem__label, .mm-menuItem__secondary-label': {
+                    color: colors.primaryText,
+                },
+
+                '.mm-icon': {
+                    '& svg path': {
+                        color: colors.primaryText,
+                    },
+                },
+            }),
         },
 
         '&:active, &.active': {
-            background: colors.primary_8,
+            background: destructive ? colors.error : colors.primary_8,
         },
 
         '&:focus': {
             outline: 'none',
-            border: `2px solid ${colors.buttonFocusBorder}`,
+            border: `2px solid ${destructive ? colors.error : colors.buttonFocusBorder}`,
         },
+
+        ...(disabled && {
+            pointerEvents: 'none',
+            opacity: '35%',
+        }),
+
+        ...(destructive && !disabled && {
+            '.mm-menuItem__label, .mm-menuItem__secondary-label': {
+                color: colors.error,
+            },
+
+            '.mm-icon': {
+                '& svg path': {
+                    color: colors.error,
+                },
+            },
+        }),
     };
 });
 


### PR DESCRIPTION
### Ticket ID
https://brightscout.atlassian.net/browse/MI-2985

### Description
- Add a destructive variant for MenuItem and disabled state
- Add leading and trailing element props
- Add onMouseEnter, onMouseLeave props

### Screenshot
![Screenshot from 2023-04-12 13-00-41](https://user-images.githubusercontent.com/115625377/231384998-97f59792-98f3-4264-a4ae-efb316d25f91.png)
![Screenshot from 2023-04-12 13-00-56](https://user-images.githubusercontent.com/115625377/231385007-9c726ddc-095c-4c34-89c3-15b9da7f9371.png)
![Screenshot from 2023-04-12 13-01-10](https://user-images.githubusercontent.com/115625377/231385009-628978c7-dab8-4b25-8870-05c858238537.png)
![Screenshot from 2023-04-12 13-02-05](https://user-images.githubusercontent.com/115625377/231385011-f66efeff-7838-49ce-8d47-67a2f1684faf.png)
